### PR TITLE
Do bit-shifting in parents, not children.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ pom.xml.asc
 .lein-failures
 .lein-plugins
 .lein-repl-history
+.nrepl-port

--- a/src/cljx/org/nfrac/comportex/cortical_io.cljx
+++ b/src/cljx/org/nfrac/comportex/cortical_io.cljx
@@ -44,8 +44,8 @@
 
 (defn random-sdr
   []
-  (set (repeatedly (* retina-size 0.02)
-                   #(util/rand-int (dec retina-size)))))
+  (distinct (repeatedly (* retina-size 0.02)
+                        #(util/rand-int (dec retina-size)))))
 
 (defn scramble-bit
   "Maps a retina fingerprint index to another index which is spatially
@@ -71,7 +71,7 @@
 
 (defn scramble-bitset
   [bits]
-  (into #{} (map scramble-bit bits)))
+  (map scramble-bit bits))
 
 (defn ?assoc
   "assoc, but not if the key already has a (truthy) value."
@@ -122,12 +122,6 @@
         (recur (inc min-votes))
         bits))))
 
-(defn apply-offset
-  [xs offset]
-  (->> xs
-       (map #(+ % offset))
-       (into (empty xs))))
-
 (defn cortical-io-encoder
   [api-key cache & {:keys [decode-locally? spatial-scramble?]}]
   (let [topo (topology/make-topology retina-dim)]
@@ -137,13 +131,12 @@
         topo)
       p/PEncodable
       (encode
-        [_ offset term]
+        [_ term]
         (if (seq term)
           (cond->
            (get-fingerprint cache term)
-           spatial-scramble? (scramble-bitset)
-           (not (zero? offset)) (apply-offset offset))
-          #{}))
+           spatial-scramble? (scramble-bitset))
+          (sequence nil)))
       (decode
         [this bit-votes n]
         (let [bit-votes (if spatial-scramble?

--- a/src/cljx/org/nfrac/comportex/protocols.cljx
+++ b/src/cljx/org/nfrac/comportex/protocols.cljx
@@ -38,13 +38,13 @@
   "A feed-forward input source with a bit set representation. Could be
    sensory input or a region (where cells are bits)."
   (ff-topology [this])
-  (bits-value [this offset])
-  (signal-bits-value [this offset])
+  (bits-value [this])
+  (signal-bits-value [this])
   (source-of-bit [this i]))
 
 (defprotocol PFeedForwardMotor
   (ff-motor-topology [this])
-  (motor-bits-value [this offset]))
+  (motor-bits-value [this]))
 
 (defprotocol PLayerOfCells
   (layer-activate [this ff-bits signal-ff-bits])
@@ -89,9 +89,8 @@
 
 (defprotocol PEncodable
   "Encoders need to extend this together with PTopological."
-  (encode [this offset x]
-    "Encodes `x` as a set of integers which are the on-bits, starting
-     from the given offset.")
+  (encode [this x]
+    "Encodes `x` as a set of integers which are the on-bits.")
   (decode [this bit-votes n]
     "Finds `n` domain values matching the given bit set in a sequence
      of maps with keys `:value`, `:votes-frac`, `:votes-per-bit`,

--- a/src/cljx/org/nfrac/comportex/util.cljx
+++ b/src/cljx/org/nfrac/comportex/util.cljx
@@ -198,3 +198,16 @@
           ;; exclude this one
           :else
           (recur (next ms) am curr-min)))))))
+
+(defn align-indices
+  "Using the provided widths and a coll of colls of indices, lazily adjust
+  each index so that each coll of indices starts where the previous coll ended.
+  Lazily concat all results."
+  ([widths]
+     ;; reserving arity -- this could become a transducer
+     :not-implemented)
+  ([widths collcoll]
+     (let [[leftmost & others] collcoll
+           offs (reductions + widths)]
+       (concat leftmost
+               (mapcat #(map (partial + %) %2) offs others)))))

--- a/test/cljx/org/nfrac/comportex/spatial_pooling_test.cljx
+++ b/test/cljx/org/nfrac/comportex/spatial_pooling_test.cljx
@@ -77,7 +77,8 @@
                             [:mid 8]
                             [:far 25]]
                      :let [this-in (mapv (partial + d) in)
-                           rgn2 (p/region-step rgn (p/encode encoder 0 this-in))]]
+                           ff-bits (into #{} (p/encode encoder this-in))
+                           rgn2 (p/region-step rgn ff-bits)]]
                  [k (p/active-columns (:layer-3 rgn2))])
                (into {}))]
         (is (> (count (set/intersection (:orig m) (:near m)))


### PR DESCRIPTION
Remove awareness of siblings from regions / encoders. Rather than returning a set of final indices, return a lazy seq of unshifted indices, allowing the caller to shift as needed.
