### PR TITLE
Truncate large collections when printing

### DIFF
--- a/src/cljx/org/nfrac/comportex/cells.cljx
+++ b/src/cljx/org/nfrac/comportex/cells.cljx
@@ -543,7 +543,7 @@
                  :signal-cells sig-ac
                  ;; for convenience / efficiency in other steps
                  :active-cells-by-col acbc}))))
-  
+
   (layer-learn
     [this]
     (let [ff-bits (:ff-bits state)
@@ -580,7 +580,7 @@
                        (:active-cols state) dcp)
        boost? (columns/update-boosting)
        boost? (update-inhibition-radius))))
-  
+
   (layer-depolarise
     [this distal-ff-bits distal-fb-bits]
     ;; TODO distal-bits
@@ -592,7 +592,7 @@
         :pred-state (map->LayerPredictiveState
                      {:distal-exc cell-exc
                       :pred-cells pc}))))
-  
+
   (layer-depth [_]
     (:depth spec))
   (bursting-columns [_]
@@ -624,6 +624,10 @@
   p/PParameterised
   (params [_]
     spec))
+
+(util/print-method-truncate LayerOfCells [:boosts
+                                          :active-duty-cycles
+                                          :overlap-duty-cycles])
 
 (defn layer-of-cells
   [spec]

--- a/src/cljx/org/nfrac/comportex/synapses.cljx
+++ b/src/cljx/org/nfrac/comportex/synapses.cljx
@@ -87,6 +87,8 @@
         (update-in [:targets-by-source]
                    util/update-each syn-source-ids #(disj % target-id)))))
 
+(util/print-method-truncate SynapseGraph [:syns-by-target :targets-by-source])
+
 (defn empty-synapse-graph
   [n-targets n-sources pcon max-syns cull-zeros?]
   (map->SynapseGraph


### PR DESCRIPTION
Addresses #2 .

At first I applied `*print-length*` to the entire record, but that was bad because the truncation also applied to the record itself, hiding entire fields. So here's what I came up with.
