### PR TITLE
Untangle REPL code from HTM code, autoload more responsibly

### DIFF
--- a/dev/user.clj
+++ b/dev/user.clj
@@ -1,0 +1,11 @@
+;; Clojure loads user.clj long before cljx is loaded.
+;; This hack is only necessary within the comportex project --
+;; other comportex consumers never see the cljx files.
+(require '[cljx.repl-middleware :as cljx])
+(reset! @#'cljx/cljx-load-rules {:clj cljx.rules/clj-rules})
+@@#'cljx/install-cljx-load
+
+(ns user
+  (:require org.nfrac.comportex.repl))
+
+(org.nfrac.comportex.repl/truncate-large-data-structures)

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "http://github.com/nupic-community/comportex/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :source-paths ["src/cljx" "target/classes"]
+  :source-paths ["src/cljx"]
   :test-paths ["target/test-classes"]
   :dependencies [[org.clojure/clojure "1.6.0"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
@@ -15,33 +15,39 @@
   :jar-exclusions [#"\.cljx"]
   :jvm-opts ^:replace ["-server" "-Xmx2500m"]
 
-  :profiles {:dev {:dependencies [[org.clojure/clojurescript "0.0-2234"]
+  :cljx {:builds [{:source-paths ["src/cljx"]
+                   :output-path "target/classes"
+                   :rules :clj}
+
+                  {:source-paths ["src/cljx"]
+                   :output-path "target/classes"
+                   :rules :cljs}
+
+                  {:source-paths ["test/cljx"]
+                   :output-path "target/test-classes"
+                   :rules :clj}
+
+                  {:source-paths ["test/cljx"]
+                   :output-path "target/test-classes"
+                   :rules :cljs}]}
+
+  :cljsbuild {:builds [{:source-paths ["target/classes"
+                                       "target/test-classes"]
+                        :jar true
+                        :compiler {:output-to "target/testable.js"
+                                   :optimizations :advanced}}]}
+
+  :profiles {:dev {:source-paths ["dev"]
+                   :dependencies [[org.clojure/clojurescript "0.0-2234"]
                                   [criterium "0.4.3"]]
                    :plugins [[com.keminglabs/cljx "0.4.0"]
                              [lein-cljsbuild "1.0.3"]
                              [com.cemerick/clojurescript.test "0.3.1"]
                              [com.cemerick/austin "0.1.4"]
                              [lein-marginalia "0.8.0"]]
-                   :cljx {:builds [{:source-paths ["src/cljx"]
-                                    :output-path "target/classes"
-                                    :rules :clj}
-
-                                   {:source-paths ["src/cljx"]
-                                    :output-path "target/classes"
-                                    :rules :cljs}
-
-                                   {:source-paths ["test/cljx"]
-                                    :output-path "target/test-classes"
-                                    :rules :clj}
-
-                                   {:source-paths ["test/cljx"]
-                                    :output-path "target/test-classes"
-                                    :rules :cljs}]}
 
                    :auto-clean false
-                   :prep-tasks [["cljx" "once"]]
 
-                   :cljsbuild {:builds [{:source-paths ["target/classes" "target/test-classes"]
-                                         :jar true
-                                         :compiler {:output-to "target/testable.js"
-                                                    :optimizations :advanced}}]}}})
+                   :aliases {"install" ["do" "clean,"
+                                        "cljx" "once,"
+                                        "install"]}}})

--- a/src/cljx/org/nfrac/comportex/repl.cljx
+++ b/src/cljx/org/nfrac/comportex/repl.cljx
@@ -1,0 +1,55 @@
+(ns org.nfrac.comportex.repl
+  "Optional REPL tweaks"
+  (:require #+clj [clojure.pprint :as pprint]
+            [org.nfrac.comportex.cells
+             #+cljs :refer #+cljs [LayerOfCells]]
+            [org.nfrac.comportex.synapses
+             #+cljs :refer #+cljs [SynapseGraph]])
+  #+clj
+  (:import [org.nfrac.comportex.cells LayerOfCells]
+           [org.nfrac.comportex.synapses SynapseGraph]))
+
+;;; ## Truncate large data structures
+
+(defn patchmethod1
+  "Transform the first argument of calls to `multifn` before calling the method
+  currently associated with dispatch-value. This transform happens after
+  dispatch."
+  [multifn dispatch-val f]
+  (let [dispatch-fn (get-method multifn dispatch-val)]
+    (defmethod multifn dispatch-val
+      [arg1 & more]
+      (apply dispatch-fn (f arg1) more))))
+
+(def ^:dynamic *truncated-print-length* 3)
+
+(def print-methods [#+clj print-method
+                    #+clj pprint/simple-dispatch])
+
+(def should-truncate {LayerOfCells
+                      [:boosts :active-duty-cycles :overlap-duty-cycles],
+                      SynapseGraph
+                      [:syns-by-target :targets-by-source]})
+
+(defrecord TruncateOnPrint [v])
+
+(defn truncate-large-data-structures []
+  ;; The TruncateOnPrint is invisible. Its contents are visible, but truncated.
+  (doseq [m print-methods]
+    (defmethod m TruncateOnPrint
+      [this & args]
+      (binding [*print-length* (if (and *print-length*
+                                        *truncated-print-length*)
+                                 (min *print-length*
+                                      *truncated-print-length*)
+                                 (or *print-length*
+                                     *truncated-print-length*))]
+        (apply m (:v this) args))))
+
+  ;; Before printing records, wrap the specified fields in a TruncateOnPrint.
+  (doseq [m print-methods
+          [recordclass noisykeys] should-truncate]
+    (patchmethod1 m recordclass
+                  (fn [this]
+                    (reduce #(update-in % [%2] ->TruncateOnPrint)
+                            this noisykeys)))))


### PR DESCRIPTION
It was non-trivial to get user.clj to load cljx code, since Clojure loads user.clj long before running the project's prep-tasks

project.clj change commentary:
- Rely on cljx's repl-middleware to load cljx files, rather than falling back to "target/classes"
- Stopped running "cljx once" all the time. Only use it on install.
- Remove generated paths from :source-paths. It's sufficient for this code to sit in target/classes. There were lots of "duplicate file" errors on install, and this was why.
- cljx folder is still included in :source-paths because some tools use it for go-to-definition, and because there's a single .clj file in src
- Moved :cljx and :cljsbuild spec out of profiles. It's good enough to scope the plugin to the profile.
- "lein do check, install" is no longer right. "lein do install, check" or "lein do cljx, check" are valid.

Also, a better fix to the recent cljs :import regression. Import classes via :require in cljs (though Clojure requires :import)
