### PR TITLE
Separate encoders from senses

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject org.nfrac/comportex "0.0.9-SNAPSHOT"
+(defproject org.nfrac/comportex "0.0.10-SNAPSHOT"
   :description "Functionally composable cortex, an implementation of Hierarchical Temporal Memory"
   :url "http://github.com/nupic-community/comportex/"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0-RC1"]
+  :dependencies [[org.clojure/clojure "1.7.0"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [org.clojure/data.int-map "0.1.0"]
                  [com.cemerick/pprng "0.0.3"]
@@ -16,9 +16,9 @@
                         :compiler {:output-to "target/testable.js"
                                    :optimizations :advanced}}]}
 
-  :profiles {:dev {:dependencies [[org.clojure/clojurescript "0.0-3211"]
+  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.7.107"]
                                   [criterium "0.4.3"]]
-                   :plugins [[lein-cljsbuild "1.0.5"]
+                   :plugins [[lein-cljsbuild "1.1.0"]
                              [com.cemerick/clojurescript.test "0.3.3"]
                              ;[lein-marginalia "0.8.1-SNAPSHOT"]
                              ]}

--- a/src/org/nfrac/comportex/demos/coordinates_2d.cljc
+++ b/src/org/nfrac/comportex/demos/coordinates_2d.cljc
@@ -70,6 +70,6 @@
   ([n]
      (n-region-model n spec))
   ([n spec]
-     (core/regions-in-series core/sensory-region (core/sensory-input encoder)
+     (core/regions-in-series core/sensory-region encoder
                              n
                              (list* spec (repeat (merge spec higher-level-spec-diff))))))

--- a/src/org/nfrac/comportex/demos/directional_steps_1d.cljc
+++ b/src/org/nfrac/comportex/demos/directional_steps_1d.cljc
@@ -50,6 +50,6 @@
   ([n]
      (n-region-model n spec))
   ([n spec]
-     (core/regions-in-series core/sensory-region (core/sensory-input encoder)
+     (core/regions-in-series core/sensory-region encoder
                              n
                              (list* spec (repeat (merge spec higher-level-spec-diff))))))

--- a/src/org/nfrac/comportex/demos/isolated_1d.cljc
+++ b/src/org/nfrac/comportex/demos/isolated_1d.cljc
@@ -90,6 +90,6 @@
      (n-region-model n spec))
   ([n spec]
      (core/regions-in-series core/sensory-region
-                             (core/sensory-input block-encoder)
+                             block-encoder
                              n
                              (list* spec (repeat (merge spec higher-level-spec-diff))))))

--- a/src/org/nfrac/comportex/demos/isolated_2d.cljc
+++ b/src/org/nfrac/comportex/demos/isolated_2d.cljc
@@ -93,7 +93,6 @@
   ([n]
      (n-region-model n spec))
   ([n spec]
-     (core/regions-in-series core/sensory-region
-                             (core/sensory-input block-encoder)
+     (core/regions-in-series core/sensory-region block-encoder
                              n
                              (list* spec (repeat (merge spec higher-level-spec-diff))))))

--- a/src/org/nfrac/comportex/demos/letters.cljc
+++ b/src/org/nfrac/comportex/demos/letters.cljc
@@ -40,6 +40,5 @@
   ([n spec]
    (n-region-model n spec block-encoder))
   ([n spec encoder]
-   (let [inp (core/sensory-input encoder)]
-     (core/regions-in-series core/sensory-region inp n
-                             (list* spec (repeat (merge spec higher-level-spec-diff)))))))
+   (core/regions-in-series core/sensory-region encoder n
+                           (list* spec (repeat (merge spec higher-level-spec-diff))))))

--- a/src/org/nfrac/comportex/demos/mixed_gaps_1d.cljc
+++ b/src/org/nfrac/comportex/demos/mixed_gaps_1d.cljc
@@ -79,6 +79,6 @@
      (n-region-model n spec))
   ([n spec]
      (core/regions-in-series core/sensory-region
-                             (core/sensory-input block-encoder)
+                             block-encoder
                              n
                              (list* spec (repeat (merge spec higher-level-spec-diff))))))

--- a/src/org/nfrac/comportex/demos/q_learning_1d.cljc
+++ b/src/org/nfrac/comportex/demos/q_learning_1d.cljc
@@ -139,16 +139,15 @@
                                      {:coord [(* x surface-coord-scale)]
                                       :radii [coord-radius]})
                                    (enc/coordinate-encoder input-dim on-bits))
-        mencoder (enc/pre-transform :dx (enc/linear-encoder 100 30 [-1 1]))
-        sensory-input (core/sensorimotor-input encoder encoder)
-        motor-input (core/sensorimotor-input nil mencoder)]
+        mencoder (enc/pre-transform :dx (enc/linear-encoder 100 30 [-1 1]))]
     (core/region-network {:rgn-1 [:input :motor]
                           :action [:rgn-1]}
-                         {:input sensory-input
-                          :motor motor-input}
-                         core/sensory-region
+                         (constantly core/sensory-region)
                          {:rgn-1 (assoc spec :lateral-synapses? false)
-                          :action action-spec})))
+                          :action action-spec}
+                         {:input encoder}
+                         {:input encoder
+                          :motor mencoder})))
 
 (defn feed-world-c-with-actions!
   [in-model-steps-c out-world-c model-atom]

--- a/src/org/nfrac/comportex/demos/q_learning_2d.cljc
+++ b/src/org/nfrac/comportex/demos/q_learning_2d.cljc
@@ -116,16 +116,15 @@
                                    (enc/coordinate-encoder input-dim on-bits))
         mencoder (enc/pre-transform (juxt :dx :dy)
                                     (enc/encat 2
-                                               (enc/linear-encoder 100 30 [-1 1])))
-        sensory-input (core/sensorimotor-input encoder encoder)
-        motor-input (core/sensorimotor-input nil mencoder)]
+                                               (enc/linear-encoder 100 30 [-1 1])))]
     (core/region-network {:rgn-1 [:input :motor]
                           :action [:rgn-1]}
-                         {:input sensory-input
-                          :motor motor-input}
-                         core/sensory-region
+                         (constantly core/sensory-region)
                          {:rgn-1 (assoc spec :lateral-synapses? false)
-                          :action action-spec})))
+                          :action action-spec}
+                         {:input encoder}
+                         {:input encoder
+                          :motor mencoder})))
 
 (defn feed-world-c-with-actions!
   [in-model-steps-c out-world-c model-atom]

--- a/src/org/nfrac/comportex/demos/repeat.cljc
+++ b/src/org/nfrac/comportex/demos/repeat.cljc
@@ -48,6 +48,6 @@
      (n-region-model n spec))
   ([n spec]
      (core/regions-in-series core/sensory-region
-                             (core/sensory-input block-encoder)
+                             block-encoder
                              n
                              (list* spec (repeat (merge spec higher-level-spec-diff))))))

--- a/src/org/nfrac/comportex/demos/sensorimotor_1d.cljc
+++ b/src/org/nfrac/comportex/demos/sensorimotor_1d.cljc
@@ -59,16 +59,14 @@
       :last-saccade dx
       :next-saccade sacc)))
 
-(def block-sensory-input
-  (let [e (enc/pre-transform #(get (:field %) (:position %))
-                             (enc/category-encoder bit-width items))]
-    (core/sensorimotor-input e e)))
+(def block-encoder
+  (enc/pre-transform #(get (:field %) (:position %))
+                     (enc/category-encoder bit-width items)))
 
-(def block-motor-input
-  (let [e (enc/pre-transform :next-saccade
-                             (enc/linear-encoder motor-bit-width motor-on-bits
-                                                 [(first saccades) (last saccades)]))]
-    (core/sensorimotor-input nil e)))
+(def block-motor-encoder
+  (enc/pre-transform :next-saccade
+                     (enc/linear-encoder motor-bit-width motor-on-bits
+                                         [(first saccades) (last saccades)])))
 
 (defn world-seq
   "Returns an infinite lazy seq of sensory input values."
@@ -80,6 +78,5 @@
      (n-region-model n spec))
   ([n spec]
      (core/regions-in-series core/sensorimotor-region
-                             block-sensory-input block-motor-input
-                             n
+                             block-encoder block-motor-encoder n
                              (list* spec (repeat (merge spec higher-level-spec-diff))))))

--- a/src/org/nfrac/comportex/demos/simple_sentences.cljc
+++ b/src/org/nfrac/comportex/demos/simple_sentences.cljc
@@ -126,6 +126,5 @@ Chifung has no tail.
    (let [encoder random-encoder]
      (n-region-model n spec encoder)))
   ([n spec encoder]
-   (let [inp (core/sensory-input encoder)]
-     (core/regions-in-series core/sensory-region inp n
-                             (list* spec (repeat (merge spec higher-level-spec-diff)))))))
+   (core/regions-in-series core/sensory-region encoder n
+                           (list* spec (repeat (merge spec higher-level-spec-diff))))))

--- a/test/org/nfrac/comportex/excitation_breakdowns_test.cljc
+++ b/test/org/nfrac/comportex/excitation_breakdowns_test.cljc
@@ -33,7 +33,7 @@
 
 (defn model
   []
-  (core/regions-in-series core/sensory-region (core/sensory-input encoder)
+  (core/regions-in-series core/sensory-region encoder
                           2 (repeat spec)))
 
 (defn world-seq

--- a/test/org/nfrac/comportex/sequence_memory_test.cljc
+++ b/test/org/nfrac/comportex/sequence_memory_test.cljc
@@ -38,7 +38,7 @@
 
 (defn model
   []
-  (core/regions-in-series core/sensory-region (core/sensory-input encoder)
+  (core/regions-in-series core/sensory-region encoder
                           1 [spec]))
 
 (defn world-seq

--- a/test/org/nfrac/comportex/spatial_pooling_test.cljc
+++ b/test/org/nfrac/comportex/spatial_pooling_test.cljc
@@ -35,7 +35,7 @@
 
 (defn model
   []
-  (core/regions-in-series core/sensory-region (core/sensory-input encoder)
+  (core/regions-in-series core/sensory-region encoder
                           1 [spec]))
 
 (deftest sp-test
@@ -51,8 +51,6 @@
         lyr (:layer-3 rgn)
         n-cols (p/size-of lyr)]
     (testing "Column activation is distributed and moderated."
-      (is (pos? (util/quantile (:overlap-duty-cycles lyr) 0.01))
-          "At least 99% of columns have overlapped with input at least once.")
       (is (pos? (util/quantile (:active-duty-cycles lyr) 0.9))
           "At least 10% of columns have been active.")
       (let [nactive-ts (for [t (range 400 500)]
@@ -61,7 +59,7 @@
             "Inhibition limits active columns in each time step."))
       (let [sg (:proximal-sg lyr)
             nsyns (for [col (range n-cols)]
-                    (count (p/sources-connected-to sg col)))]
+                    (count (p/sources-connected-to sg [col 0 0])))]
         (is (>= (apply min nsyns) 1)
             "All columns have at least one connected input synapse."))
       (let [bs (:boosts lyr)]


### PR DESCRIPTION
This implements half of #19 i.e. separating encoders from senses, not yet changing encoders at all.

To be coordinated with a corresponding change to ComportexViz, hence set version to 0.0.10-SNAPSHOT.

In particular, any thoughts on the argument signatures of `region-network` and `regions-in-series` (since these are important parts of the API) and the revised PHTM function names?