### PR TITLE
decompose encoders into serializable sensors

### DIFF
--- a/src/org/nfrac/comportex/core.cljc
+++ b/src/org/nfrac/comportex/core.cljc
@@ -440,11 +440,6 @@
                   (zipmap (keys regions)))]
       (assoc this :regions rm)))
 
-  (htm-export
-    [this]
-    ;; TODO - is this needed any more? Maybe a general export protocol to clear caches?
-    this)
-
   p/PTemporal
   (timestep [_]
     (p/timestep (first (vals regions))))

--- a/src/org/nfrac/comportex/core.cljc
+++ b/src/org/nfrac/comportex/core.cljc
@@ -495,7 +495,11 @@
   region-building functions, parameter specifications, and sensors in
   the remaining argments.
 
-  Sensors are defined to be the form `[selector encoder]`.
+  Sensors are defined to be the form `[selector encoder]`, satisfying
+  protocols PSelector and PEncoder respectively. Sensors in the
+  `main-sensors` map can make activating (proximal) connections while
+  those in the `motor-sensors` map can make depolarising (distal)
+  connections. The same sensor may also be included in both maps.
 
   For each node, the combined dimensions of its feed-forward sources
   is calculated and used to set the `:input-dimensions` parameter in
@@ -504,7 +508,8 @@
   the combined dimensions of its feed-back superior regions is used to
   set the `:distal-topdown-dimensions` parameter. The updated spec is
   passed to a function (typically `sensory-region`) to build a
-  region. The build function is looked up in `region-builders`.
+  region. The build function is found by calling `region-builders`
+  with the region id keyword.
 
   For example to build the network `inp -> v1 -> v2`:
 
@@ -527,6 +532,10 @@
          ;; all ids in dependency map must be defined
          (every? region-specs (keys ff-deps))
          (every? (merge main-sensors motor-sensors) (in-vals-not-keys ff-deps))]}
+  (merge-with (fn [main-sensor motor-sensor]
+                (assert (= main-sensor motor-sensor)
+                        "Equal keys in main-sensors and motor-sensors must be same sensor."))
+              main-sensors motor-sensors)
   (let [all-ids (into (set (keys ff-deps))
                       (in-vals-not-keys ff-deps))
         ff-dag (graph/directed-graph all-ids ff-deps)

--- a/src/org/nfrac/comportex/cortical_io.cljc
+++ b/src/org/nfrac/comportex/cortical_io.cljc
@@ -128,7 +128,7 @@
       p/PTopological
       (topology [_]
         topo)
-      p/PEncodable
+      p/PEncoder
       (encode
         [_ term]
         (if (seq term)

--- a/src/org/nfrac/comportex/demos/coordinates_2d.cljc
+++ b/src/org/nfrac/comportex/demos/coordinates_2d.cljc
@@ -5,7 +5,7 @@
             [org.nfrac.comportex.util :as util :refer [abs round]]))
 
 (def input-dim [30 30])
-(def on-bits 30)
+(def n-on-bits 30)
 (def max-pos 45)
 (def max-vel 5)
 (def radius 15)
@@ -55,21 +55,19 @@
            (* ay -1)
            ay)}))
 
-(def encoder
-  (enc/pre-transform (fn [{:keys [x y]}]
-                       {:coord [x y]
-                        :radii [radius radius]})
-   (enc/coordinate-encoder input-dim on-bits)))
-
-(defn world-seq
+(defn input-seq
   "Returns an infinite lazy seq of sensory input values."
   []
   (iterate input-transform initial-input-val))
 
+(def sensor
+  [(enc/vec-selector :x :y)
+   (enc/coordinate-encoder input-dim n-on-bits [1 1] [radius radius])])
+
 (defn n-region-model
   ([n]
-     (n-region-model n spec))
+   (n-region-model n spec))
   ([n spec]
-     (core/regions-in-series core/sensory-region encoder
-                             n
-                             (list* spec (repeat (merge spec higher-level-spec-diff))))))
+   (core/regions-in-series n core/sensory-region
+                           (list* spec (repeat (merge spec higher-level-spec-diff)))
+                           {:input sensor})))

--- a/src/org/nfrac/comportex/demos/cortical_io_channel.clj
+++ b/src/org/nfrac/comportex/demos/cortical_io_channel.clj
@@ -33,10 +33,9 @@
 
 (defn n-region-model
   [api-key cache n]
-  (core/regions-in-series core/sensory-region
-                          (cortical-io-encoder api-key cache)
-                          n
-                          (list* spec (repeat (merge spec higher-level-spec-diff)))))
+  (core/regions-in-series n core/sensory-region
+                          (list* spec (repeat (merge spec higher-level-spec-diff)))
+                          {:input (cortical-io-encoder api-key cache)}))
 
 (comment
 

--- a/src/org/nfrac/comportex/demos/directional_steps_1d.cljc
+++ b/src/org/nfrac/comportex/demos/directional_steps_1d.cljc
@@ -8,7 +8,7 @@
 (def numb-bit-width (- bit-width cat-bit-width))
 (def numb-max 7)
 (def numb-domain [0 numb-max])
-(def on-bits 30)
+(def n-on-bits 30)
 
 (def spec
   {:column-dimensions [500]
@@ -36,20 +36,20 @@
         new-dir (util/rand-nth [:up :down])]
     [new-dir new-i]))
 
-(def encoder
-  (enc/encat 2
-             (enc/category-encoder cat-bit-width [:down :up])
-             (enc/linear-encoder numb-bit-width on-bits numb-domain)))
-
-(defn world-seq
+(defn input-seq
   "Returns an infinite lazy seq of sensory input values."
   []
   (iterate input-transform initial-input-val))
 
+(def sensor
+  (enc/sensor-cat
+   [[0] (enc/category-encoder [cat-bit-width] [:down :up])]
+   [[1] (enc/linear-encoder [numb-bit-width] n-on-bits numb-domain)]))
+
 (defn n-region-model
   ([n]
-     (n-region-model n spec))
+   (n-region-model n spec))
   ([n spec]
-     (core/regions-in-series core/sensory-region encoder
-                             n
-                             (list* spec (repeat (merge spec higher-level-spec-diff))))))
+   (core/regions-in-series n core/sensory-region
+                           (list* spec (repeat (merge spec higher-level-spec-diff)))
+                           {:input sensor})))

--- a/src/org/nfrac/comportex/demos/letters.cljc
+++ b/src/org/nfrac/comportex/demos/letters.cljc
@@ -26,19 +26,20 @@
 
 ;; encoders expect a string in key :value of the input data item.
 
-(def block-encoder
-  (enc/pre-transform :value
-                     (enc/category-encoder bit-width tokens)))
+(def block-sensor
+  [:value
+   (enc/category-encoder [bit-width] tokens)])
 
-(def random-encoder
-  (enc/pre-transform :value
-                     (enc/unique-encoder [bit-width] bits-per-char)))
+(def random-sensor
+  [:value
+   (enc/unique-encoder [bit-width] bits-per-char)])
 
 (defn n-region-model
   ([n]
    (n-region-model n spec))
   ([n spec]
-   (n-region-model n spec block-encoder))
-  ([n spec encoder]
-   (core/regions-in-series core/sensory-region encoder n
-                           (list* spec (repeat (merge spec higher-level-spec-diff))))))
+   (n-region-model n spec block-sensor))
+  ([n spec sensor]
+   (core/regions-in-series n core/sensory-region
+                           (list* spec (repeat (merge spec higher-level-spec-diff)))
+                           {:input sensor})))

--- a/src/org/nfrac/comportex/demos/repeat.cljc
+++ b/src/org/nfrac/comportex/demos/repeat.cljc
@@ -8,8 +8,8 @@
 (def signals [:start :again :pause :stop])
 (def tokens (vec (concat signals stimuli stimuli2)))
 
-(def on-bits 20)
-(def bit-width (* on-bits (count tokens)))
+(def n-on-bits 20)
+(def bit-width (* n-on-bits (count tokens)))
 
 (def spec
   {:column-dimensions [1000]
@@ -28,15 +28,14 @@
           [:stop]
           [nil]))
 
-(def block-encoder
-  (enc/pre-transform :value
-                     (enc/category-encoder bit-width tokens)))
+(def block-sensor
+  [:value (enc/category-encoder [bit-width] tokens)])
 
 (defn repeatcat
   [n xs]
   (apply concat (repeat n xs)))
 
-(defn world-seq
+(defn input-seq
   [stimuli reps]
   (->> (concat (mapcat #(repeatcat reps (presentation 1 [%])) stimuli)
                (mapcat #(repeatcat reps (presentation 2 [%])) stimuli)
@@ -45,9 +44,8 @@
 
 (defn n-region-model
   ([n]
-     (n-region-model n spec))
+   (n-region-model n spec))
   ([n spec]
-     (core/regions-in-series core/sensory-region
-                             block-encoder
-                             n
-                             (list* spec (repeat (merge spec higher-level-spec-diff))))))
+   (core/regions-in-series n core/sensory-region
+                           (list* spec (repeat (merge spec higher-level-spec-diff)))
+                           {:input block-sensor})))

--- a/src/org/nfrac/comportex/demos/simple_sentences.cljc
+++ b/src/org/nfrac/comportex/demos/simple_sentences.cljc
@@ -106,25 +106,26 @@ Chifung has no tail.
         [j word] (map-indexed vector sen)]
     {:word word :index [i j]}))
 
-(defn make-block-encoder
+(defn make-block-sensor
   [text]
   (let [split-sens (split-sentences text)
         uniq-words (distinct (apply concat split-sens))
         bit-width (* bits-per-word (count uniq-words))]
-    (enc/pre-transform :word
-                       (enc/category-encoder bit-width uniq-words))))
+    [:word
+     (enc/category-encoder [bit-width] uniq-words)]))
 
-(def random-encoder
+(def random-sensor
   (let [bit-width 500]
-    (enc/pre-transform :word
-                       (enc/unique-encoder [bit-width] bits-per-word))))
+    [:word
+     (enc/unique-encoder [bit-width] bits-per-word)]))
 
 (defn n-region-model
   ([n]
    (n-region-model n spec))
   ([n spec]
-   (let [encoder random-encoder]
-     (n-region-model n spec encoder)))
-  ([n spec encoder]
-   (core/regions-in-series core/sensory-region encoder n
-                           (list* spec (repeat (merge spec higher-level-spec-diff))))))
+   (let [sensor random-sensor]
+     (n-region-model n spec sensor)))
+  ([n spec sensor]
+   (core/regions-in-series n core/sensory-region
+                           (list* spec (repeat (merge spec higher-level-spec-diff)))
+                           {:input sensor})))

--- a/src/org/nfrac/comportex/protocols.cljc
+++ b/src/org/nfrac/comportex/protocols.cljc
@@ -15,9 +15,7 @@
   (htm-depolarise [this]
     "Propagates lateral and feed-back activity to put cells into a
     depolarised (predictive) state. Assumes `this` has been through
-    the `htm-activate` phase already.")
-  (htm-export [this]
-    "Prepares for serialization."))
+    the `htm-activate` phase already."))
 
 (defn htm-activate
   "Takes an input value. Propagates feed-forward input through the

--- a/src/org/nfrac/comportex/protocols.cljc
+++ b/src/org/nfrac/comportex/protocols.cljc
@@ -2,36 +2,29 @@
 
 (defprotocol PHTM
   "A network of regions, forming Hierarchical Temporal Memory."
-  (sense [this in-value]
-    "Takes an input value. Applies sensors, encoding each sense as a
-    bit set, returning them in a map.")
-  (htm-activate-raw [this in-bits]
-    "Takes encoded bit sets with keys matching the HTM's
-    senses. Propagates feed-forward input through the network to
-    activate columns and cells.")
+  (htm-sense [this in-value]
+    "Takes an input value. Updates the HTM's senses by applying
+    corresponding sensors to the input value. Updates :input-value.
+    Returns updated HTM.")
+  (htm-activate [this]
+    "Propagates feed-forward input through the network to activate
+    columns and cells. Assumes senses have already been encoded, with
+    `htm-sense`. Increments the time step. Returns updated HTM.")
   (htm-learn [this]
     "Applies learning rules to synapses. Assumes `this` has been through
-    the `htm-activate` phase already.")
+    the `htm-activate` phase already. Returns updated HTM.")
   (htm-depolarise [this]
     "Propagates lateral and feed-back activity to put cells into a
     depolarised (predictive) state. Assumes `this` has been through
-    the `htm-activate` phase already."))
-
-(defn htm-activate
-  "Takes an input value. Propagates feed-forward input through the
-  network to activate columns and cells. Updates :input-value. Starts
-  a new time step."
-  [this in-value]
-  (-> this
-      (assoc :input-value in-value)
-      (htm-activate-raw (sense this in-value))))
+    the `htm-activate` phase already. Returns updated HTM."))
 
 (defn htm-step
   "Advances a HTM by one time step with the given input value. Does
-  (-> htm (htm-activate in-value) (htm-learn) (htm-depolarise))."
+  (-> htm (htm-sense in-value) (htm-activate) (htm-learn) (htm-depolarise))."
   [htm in-value]
   (-> htm
-      (htm-activate in-value)
+      (htm-sense in-value)
+      (htm-activate)
       (htm-learn)
       (htm-depolarise)))
 

--- a/src/org/nfrac/comportex/protocols.cljc
+++ b/src/org/nfrac/comportex/protocols.cljc
@@ -3,7 +3,7 @@
 (defprotocol PHTM
   "A network of regions, forming Hierarchical Temporal Memory."
   (sense [this in-value]
-    "Takes an input value. Encodes each sense's associated value to a
+    "Takes an input value. Applies sensors, encoding each sense as a
     bit set, returning them in a map.")
   (htm-activate-raw [this in-bits]
     "Takes encoded bit sets with keys matching the HTM's
@@ -124,7 +124,14 @@
   "Sense nodes need to extend this together with PFeedForward."
   (sense-activate [this bits]))
 
-(defprotocol PEncodable
+(defprotocol PSelector
+  "Pulls out a value according to some pattern, like a path or lens.
+  Should be serializable. A Sensor is defined as [Selector Encoder]."
+  (extract [this state]
+    "Extracts a value from `state` according to some configured pattern. A
+    simple example is a lookup by keyword in a map."))
+
+(defprotocol PEncoder
   "Encoders need to extend this together with PTopological."
   (encode [this x]
     "Encodes `x` as a collection of distinct integers which are the on-bits.")

--- a/test/org/nfrac/comportex/encoders_test.cljc
+++ b/test/org/nfrac/comportex/encoders_test.cljc
@@ -9,18 +9,18 @@
 
 
 (deftest encode-decode-test
-  (let [e (enc/category-encoder 10 [:a :b :c])]
-    (is (= :a (:value (first (p/decode e (frequencies (p/encode e :a)) 1)))))
+  (let [e (enc/category-encoder [10] [:a :b :c])]
+    (is (= :a (:value (first (p/dcode e (frequencies (p/encode e :a)) 1)))))
     (is (= :b (:value (first (p/decode e (frequencies (p/encode e :b)) 1)))))
     (is (= :c (:value (first (p/decode e (frequencies (p/encode e :c)) 1))))))
   )
 
 (deftest coordinate-encoder-test
-  (let [e (enc/coordinate-encoder [1000] 40)
+  (let [radius 80
+        e (enc/coordinate-encoder [1000] 40 [1 1] [radius radius])
         coords [0 10 30 90 270]
-        radius 80
         bitsets (zipmap coords
-                        (map #(set (p/encode e {:coord [%] :radii [radius]}))
+                        (map #(set (p/encode e [%]))
                              coords))
         overlap (fn [s1 s2] (count (set/intersection s1 s2)))]
     (is (> (overlap (bitsets 0) (bitsets 10))

--- a/test/org/nfrac/comportex/encoders_test.cljc
+++ b/test/org/nfrac/comportex/encoders_test.cljc
@@ -10,7 +10,7 @@
 
 (deftest encode-decode-test
   (let [e (enc/category-encoder [10] [:a :b :c])]
-    (is (= :a (:value (first (p/dcode e (frequencies (p/encode e :a)) 1)))))
+    (is (= :a (:value (first (p/decode e (frequencies (p/encode e :a)) 1)))))
     (is (= :b (:value (first (p/decode e (frequencies (p/encode e :b)) 1)))))
     (is (= :c (:value (first (p/decode e (frequencies (p/encode e :c)) 1))))))
   )

--- a/test/org/nfrac/comportex/excitation_breakdowns_test.cljc
+++ b/test/org/nfrac/comportex/excitation_breakdowns_test.cljc
@@ -9,7 +9,7 @@
                       :refer-macros (is deftest testing run-tests)])))
 
 (def bit-width 200)
-(def on-bits 20)
+(def n-on-bits 20)
 
 (def inputs
   [:a :b :c :d
@@ -18,28 +18,29 @@
    :h :g :f :e
    :d :e :a :d])
 
-(def initial-input 0)
+(def initial-input {:index 0})
 
 (defn input-transform
-  [i]
-  (mod (inc i) (count inputs)))
+  [m]
+  (update m :index #(mod (inc %) (count inputs))))
 
-(def encoder
-  (enc/pre-transform #(get inputs %)
-                     (enc/unique-encoder [bit-width] on-bits)))
+(defn world-seq
+  "Returns a sequence of sensory input values."
+  []
+  (->> (iterate input-transform initial-input)
+       (map #(assoc % :value (get inputs %)))))
+
+(def sensor
+  [:value
+   (enc/unique-encoder [bit-width] n-on-bits)])
 
 (def spec
   {})
 
 (defn model
   []
-  (core/regions-in-series core/sensory-region encoder
-                          2 (repeat spec)))
-
-(defn world-seq
-  "Returns a sequence of sensory input values."
-  []
-  (iterate input-transform initial-input))
+  (core/regions-in-series 2 core/sensory-region (repeat spec)
+                          {:input sensor}))
 
 (deftest exc-bd-test
   (util/set-seed! 0)

--- a/test/org/nfrac/comportex/perf_test.clj
+++ b/test/org/nfrac/comportex/perf_test.clj
@@ -43,7 +43,7 @@
       (println (str (newline) info))
       (perf-test-50* (demo1d/n-region-model 1 (assoc demo1d/spec :global-inhibition? true
                                                      :ff-potential-radius 1.0))
-                     (demo1d/world-seq)))))
+                     (demo1d/input-seq)))))
 
 (deftest perf-local-1d-test
   (util/set-seed! 0)
@@ -51,7 +51,7 @@
     (testing info
       (println (str (newline) info))
       (perf-test-50* (demo1d/n-region-model 1 demo1d/spec)
-                     (demo1d/world-seq)))))
+                     (demo1d/input-seq)))))
 
 (deftest perf-local-2d-test
   (util/set-seed! 0)
@@ -59,7 +59,7 @@
     (testing info
       (println (str (newline) info))
       (perf-test-50* (demo2d/n-region-model 1 demo2d/spec)
-                     (demo2d/world-seq)))))
+                     (demo2d/input-seq)))))
 
 (deftest perf-global-1d-2r-test
   (util/set-seed! 0)
@@ -67,7 +67,7 @@
     (testing info
       (println (str (newline) info))
       (perf-test-50* (demoi1d/n-region-model 2 demoi1d/spec)
-                     (demoi1d/world-seq)))))
+                     (demoi1d/input-seq)))))
 
 (deftest perf-inh-test
   (util/set-seed! 0)

--- a/test/org/nfrac/comportex/spatial_pooling_test.cljc
+++ b/test/org/nfrac/comportex/spatial_pooling_test.cljc
@@ -29,14 +29,15 @@
            :lateral-synapses? false
            })
 
-(def encoder
-  (enc/encat n-in-items
-             (enc/linear-encoder numb-bits numb-on-bits numb-domain)))
+(def sensor
+  [[]
+   (enc/encat (repeat n-in-items
+                      (enc/linear-encoder [numb-bits] numb-on-bits numb-domain)))])
 
 (defn model
   []
-  (core/regions-in-series core/sensory-region encoder
-                          1 [spec]))
+  (core/regions-in-series 1 core/sensory-region [spec]
+                          {:input sensor}))
 
 (deftest sp-test
   (util/set-seed! 0)
@@ -74,6 +75,7 @@
                             [:mid 8]
                             [:far 25]]
                      :let [this-in (mapv (partial + d) in)
+                           [_ encoder] sensor
                            ff-bits (into #{} (p/encode encoder this-in))
                            rgn2 (p/region-step rgn ff-bits)]]
                  [k (p/active-columns (:layer-3 rgn2))])


### PR DESCRIPTION
Fixes #19 

Sensors are defined as `[selector encoder]`. Both selectors and encoders are serializable; so HTM models should now be fully serializable.

This requires changes to all user code to define sensors. The argument list of `regions-in-series` has changed.

Is it too confusing to have "sensors" as well as "senses" (the stateful output of sensors)?

What about htm-export ... thinking we might need a general export protocol to clear out any caches (e.g. encoder caches) and compress the model - e.g. removing the reverse index in SynapseGraphs which can be rebuilt ("import" protocol?)...