### PR TITLE
new pattern for autonomous action selection.

### DIFF
--- a/src/org/nfrac/comportex/core.cljc
+++ b/src/org/nfrac/comportex/core.cljc
@@ -385,16 +385,22 @@
     [ff-deps fb-deps strata sensors senses regions]
   p/PHTM
   (htm-sense
-    [this in-value]
+    [this inval mode]
     (let [sm (reduce-kv (fn [m k sense-node]
-                          (let [[selector encoder] (get sensors k)
-                                in-bits (p/encode encoder (p/extract selector in-value))]
-                            (assoc m k (p/sense-activate sense-node in-bits))))
-                        {}
+                          (if (case mode
+                                :sensory (:sensory? sense-node)
+                                :motor (:motor? sense-node)
+                                nil true)
+                            (let [[selector encoder] (get sensors k)
+                                  in-bits (->> (p/extract selector inval)
+                                               (p/encode encoder))]
+                              (assoc m k (p/sense-activate sense-node in-bits)))
+                            m))
+                        senses
                         senses)]
       (assoc this
              :senses sm
-             :input-value in-value)))
+             :input-value inval)))
 
   (htm-activate
     [this]

--- a/src/org/nfrac/comportex/demos/q_learning_2d.cljc
+++ b/src/org/nfrac/comportex/demos/q_learning_2d.cljc
@@ -5,9 +5,8 @@
             [org.nfrac.comportex.encoders :as enc]
             [org.nfrac.comportex.util :as util :refer [round abs]]
             [org.nfrac.comportex.demos.q-learning-1d :refer [q-learn]]
-            #?(:clj [clojure.core.async :refer [<! >! go]]
-               :cljs [cljs.core.async :refer [<! >!]]))
-    #?(:cljs (:require-macros [cljs.core.async.macros :refer [go]])))
+            #?(:clj [clojure.core.async :refer [put!]]
+               :cljs [cljs.core.async :refer [put!]])))
 
 (def input-dim [10 40])
 (def grid-w 7)
@@ -31,12 +30,12 @@
          empty-reward)))
    (mapv vec)))
 
-(def initial-input-val
+(def initial-inval
   {:x 0
    :y 0
-   :dy 0
-   :dx 0
-   :z 0})
+   :z 0
+   :action {:dx 0
+            :dy 0}})
 
 (def spec
   {:column-dimensions [30 30]
@@ -71,13 +70,13 @@
    ;; disable learning
    :freeze? true})
 
-(def action->movement
-  {:up [0 -1]
-   :down [0 1]
-   :left [-1 0]
-   :right [1 0]})
+(def direction->action
+  {:up {:dx 0 :dy -1}
+   :down {:dx 0 :dy 1}
+   :left {:dx -1 :dy 0}
+   :right {:dx 1 :dy 0}})
 
-(defn possible-actions
+(defn possible-directions
   [[x y]]
   (cond-> #{:up :down :left :right}
           (zero? x) (disj :left)
@@ -93,11 +92,11 @@
             [motion influence])))
 
 (defn select-action
-  [model curr-pos]
-  (let [alyr (get-in model [:regions :action :layer-3])
+  [htm curr-pos]
+  (let [alyr (get-in htm [:regions :action :layer-3])
         acols (p/active-columns alyr)
         signals (map column->signal acols)
-        poss (possible-actions curr-pos)]
+        poss (possible-directions curr-pos)]
     (->> signals
          (reduce (fn [m [motion influence]]
                    (assoc! m motion (+ (get m motion 0) influence)))
@@ -105,7 +104,26 @@
          (persistent!)
          (filter (comp poss key))
          (apply max-key val)
-         (key))))
+         (key)
+         (direction->action))))
+
+(defn apply-action
+  [inval]
+  (let [x (:x inval)
+        y (:y inval)
+        dx (:dx (:action inval))
+        dy (:dy (:action inval))
+        next-x (-> (+ x dx)
+                   (min (dec grid-w))
+                   (max 0))
+        next-y (-> (+ y dy)
+                   (min (dec grid-h))
+                   (max 0))
+        next-z (get-in surface [next-x next-y])]
+    (assoc inval
+           :x next-x
+           :y next-y
+           :z next-z)))
 
 (defn make-model
   []
@@ -113,8 +131,8 @@
                 (enc/coordinate-encoder input-dim n-on-bits
                                         [surface-coord-scale surface-coord-scale]
                                         [coord-radius coord-radius])]
-        dx-sensor [:dx (enc/linear-encoder [100] 30 [-1 1])]
-        dy-sensor [:dy (enc/linear-encoder [100] 30 [-1 1])]
+        dx-sensor [[:action :dx] (enc/linear-encoder [100] 30 [-1 1])]
+        dy-sensor [[:action :dy] (enc/linear-encoder [100] 30 [-1 1])]
         msensor (enc/sensor-cat dx-sensor dy-sensor)]
     (core/region-network {:rgn-1 [:input :motor]
                           :action [:rgn-1]}
@@ -125,66 +143,61 @@
                          {:input sensor
                           :motor msensor})))
 
-(defn feed-world-c-with-actions!
-  [in-model-steps-c out-world-c model-atom]
-  (go
-   (loop [inval (assoc initial-input-val
-                       :Q-map {})
-          prev-htm @model-atom]
-     (>! out-world-c inval)
-     (when-let [htm (<! in-model-steps-c)]
-       ;; scale reward to be comparable to [0-1] permanences
-       (let [reward (* 0.01 (:z inval))
-             ;; do the Q learning on previous step
-             upd-htm (swap! model-atom q-learn prev-htm reward)
-             ;; maintain map of state+action -> approx Q values, for diagnostics
-             info (get-in upd-htm [:regions :action :layer-3 :Q-info])
-             newQ (-> (+ (:Q-prev info 0) (:adj info 0))
-                      (max -1.0)
-                      (min 1.0))
-             Q-map (assoc (:Q-map inval)
-                          (select-keys inval [:x :y :dx :dy])
-                          newQ)]
-         (if (>= (abs (:z inval)) 100)
-           ;; terminal state, restart
-           (recur (assoc initial-input-val
-                         :Q-map Q-map)
-                  upd-htm)
-           (let [x (:x inval)
-                 y (:y inval)
-                 act (select-action upd-htm [x y])
-                 [dx dy] (action->movement act)
-                 next-x (-> (+ x dx)
-                            (min (dec grid-w))
-                            (max 0))
-                 next-y (-> (+ y dy)
-                            (min (dec grid-h))
-                            (max 0))
-                 next-z (get-in surface [next-x next-y])]
-             (recur {:x next-x
-                     :y next-y
-                     :dx dx
-                     :dy dy
-                     :z next-z
-                     :Q-map Q-map}
-                    upd-htm))))))))
+(defn htm-step-with-action-selection
+  [world-c]
+  (fn [htm inval]
+    (let [;; do first part of step, but not depolarise yet (depends on action)
+          htm-a (-> htm
+                    (p/htm-sense inval :sensory)
+                    (p/htm-activate)
+                    (p/htm-learn))
+          ;; scale reward to be comparable to [0-1] permanences
+          reward (* 0.01 (:z inval))
+          terminal-state? (>= (abs (:z inval)) 100)
+          ;; do the Q learning update on action layer (except initially)
+          upd-htm (if (:prev-action inval)
+                    (q-learn htm-a htm reward)
+                    (assoc-in htm-a [:regions :action :layer-3 :Q-info] {}))
+          ;; maintain map of state+action -> approx Q values, for diagnostics
+          info (get-in upd-htm [:regions :action :layer-3 :Q-info])
+          newQ (-> (+ (:Q-old info 0) (:adj info 0))
+                   (max -1.0)
+                   (min 1.0))
+          Q-map (assoc (:Q-map inval)
+                       (select-keys inval [:x :y :action])
+                       newQ)
+          action (select-action upd-htm [(:x inval) (:y inval)])
+          inval-with-action (assoc inval
+                                   :action action
+                                   :prev-action (:action inval)
+                                   :Q-map Q-map)]
+      ;; calculate the next position
+      (let [new-inval (if terminal-state?
+                        ;; restart
+                        (assoc initial-inval :Q-map Q-map)
+                        ;; continuing
+                        (apply-action inval-with-action))]
+        (put! world-c new-inval))
+      (cond-> upd-htm
+          true
+          (p/htm-sense inval-with-action :motor)
+          true
+          (p/htm-depolarise)
+          terminal-state?
+          (p/break)))))
 
 (comment
   (require '[clojure.core.async :as async :refer [>!! <!!]])
-  (require '[org.nfrac.comportex.protocols :as p])
   (def world-c (async/chan))
   (def model (atom (make-model)))
-  (def steps-c (async/chan))
+  (def step (htm-step-with-action-selection world-c))
 
-  (feed-world-c-with-actions! steps-c world-c model)
+  (def inval initial-inval)
+  (swap! model step inval)
+  (def inval (<!! world-c))
 
-  (def inv (<!! world-c))
-  (def model2 (swap! model p/htm-step inv))
-  (>!! steps-c model2)
-
-  inv
-  (get-in @model [:regions :action :layer-3 :state :Q-val])
-  (get-in @model [:regions :action :layer-3 :state :Q-info])
+  inval
+  (get-in @model [:regions :action :layer-3 :Q-info])
   (get-in @model [:regions :action :layer-3 :state :active-cols])
 
   )

--- a/src/org/nfrac/comportex/protocols.cljc
+++ b/src/org/nfrac/comportex/protocols.cljc
@@ -1,11 +1,12 @@
 (ns org.nfrac.comportex.protocols)
 
 (defprotocol PHTM
-  "A network of regions, forming Hierarchical Temporal Memory."
-  (htm-sense [this in-value]
+  "A network of regions and senses, forming Hierarchical Temporal Memory."
+  (htm-sense [this inval mode]
     "Takes an input value. Updates the HTM's senses by applying
-    corresponding sensors to the input value. Updates :input-value.
-    Returns updated HTM.")
+    corresponding sensors to the input value. `mode` may be
+    :sensory or :motor to update only such senses, or nil to update
+    all. Also updates :input-value. Returns updated HTM.")
   (htm-activate [this]
     "Propagates feed-forward input through the network to activate
     columns and cells. Assumes senses have already been encoded, with
@@ -19,11 +20,11 @@
     the `htm-activate` phase already. Returns updated HTM."))
 
 (defn htm-step
-  "Advances a HTM by one time step with the given input value. Does
-  (-> htm (htm-sense in-value) (htm-activate) (htm-learn) (htm-depolarise))."
-  [htm in-value]
+  "Advances a HTM by a full time step with the given input value. Just
+  (-> htm (htm-sense inval nil) htm-activate htm-learn htm-depolarise)"
+  [htm inval]
   (-> htm
-      (htm-sense in-value)
+      (htm-sense inval nil)
       (htm-activate)
       (htm-learn)
       (htm-depolarise)))


### PR DESCRIPTION
Autonomous action selection in the 3 such demos (q-learning-1d / -2d / second-level-motor) is now done with a custom htm-step function. It does the first stage, activation, then selects an action before completing the depolarisation stage with an updated input value. Specifically, only the :action component of the input value is updated. The function also puts the input value for the next timestep onto the world channel.

Accordingly, htm-sense gains a mode argument to restrict the senses to update, to either :sensory or :motor.

Yes it is embarrassing that I didn't do it this way from the beginning.