### PR TITLE
Rethink temporal pooling - discrete transitions at higher levels.

### DIFF
--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -133,7 +133,12 @@
 
    * `activation-level` - fraction of columns that can be
      active (either locally or globally); inhibition kicks in to
-     reduce it to this level.
+     reduce it to this level. Does not apply to temporal pooling.
+
+   * `activation-level-max` - maximum fraction of columns that can be
+     active as temporal pooling progresses. Each step of continued
+     pooling allocates an extra 50% of `activation-level` until this
+     maximum is reached.
 
    * `global-inhibition?` - whether to use the faster global algorithm
      for column inhibition (just keep those with highest overlap
@@ -165,7 +170,7 @@
    * `temporal-pooling-max-exc` - maximum continuing temporal pooling
      excitation level.
 
-  * `temporal-pooling-fall` - amount by which a cell's continuing
+   * `temporal-pooling-fall` - amount by which a cell's continuing
      temporal pooling excitation falls each time step in the absence of
      stable input.
 "

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -737,6 +737,7 @@
     (let [;; proximal excitation in number of active synapses, keyed by [col 0 seg-idx]
           col-seg-overlaps (p/excitations proximal-sg ff-bits
                                           (:ff-stimulus-threshold spec))
+          ;; these all keyed by [col 0]
           [col-exc ff-seg-paths ff-good-paths]
           (best-segment-excitations-and-paths col-seg-overlaps
                                               (:ff-seg-new-synapse-count spec))
@@ -755,7 +756,7 @@
           tp-exc (cond-> (:temporal-pooling-exc state)
                    (not (:engaged? state))
                    (decay-tp (:temporal-pooling-fall spec)))
-          [eff-col-exc
+          [eff-col-exc*
            eff-tp-exc] (cond
                          (not higher-level?)
                          [col-exc
@@ -767,6 +768,7 @@
                          :else
                          [(select-keys col-exc (keys ff-good-paths))
                           tp-exc])
+          eff-col-exc (columns/apply-overlap-boosting eff-col-exc* boosts)
           ;; combine excitation values for selecting columns
           abs-cell-exc (total-excitations eff-col-exc eff-tp-exc
                                           (:distal-exc distal-state)

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -805,7 +805,9 @@
                      (remove (set old-winners) new-winners))
           ;; update continuing TP activation
           next-tp-exc (if higher-level?
-                        (let [new-ac (set/difference ac (:active-cells state))]
+                        (let [new-ac (if newly-engaged?
+                                       ac
+                                       (set/difference ac (:active-cells state)))]
                           (into eff-tp-exc
                                (map vector new-ac
                                     (repeat (:temporal-pooling-max-exc spec)))))

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -397,8 +397,8 @@
     (if (zero? distal-weight)
       (into {} basic-exc)
       (let [basic-exc (if spontaneous-activation?
-                        (merge (zipmap (keys distal-exc) (repeat 0.0))
-                               (into {} basic-exc))
+                        (into (zipmap (keys distal-exc) (repeat 0.0))
+                              basic-exc)
                         basic-exc)]
         ;; add distal values
         (persistent!

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -750,10 +750,6 @@
           [raw-col-exc ff-seg-paths ff-good-paths]
           (best-segment-excitations-and-paths col-seg-overlaps
                                               (:ff-seg-new-synapse-count spec))
-          ;; stable inputs (from predicted source cells)
-          stable-col-seg-overlaps (p/excitations proximal-sg stable-ff-bits
-                                                 (:ff-stimulus-threshold spec))
-          stable-col-exc (best-segment-excitations stable-col-seg-overlaps)
           ;; temporal pooling, depending on stability of input bits.
           ;; also check for clear matches, these override pooling
           higher-level? (> (:ff-max-segments spec) 1)

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -779,10 +779,8 @@
           ;; * include distal excitation on predicted cells.
           ;; * matching segments below connected threshold get a bonus.
           ;; * cells with inactive segments get a penalty.
-          carry-forward? (not newly-engaged?)
           rel-cell-exc (->> (within-column-cell-exc a-cols
-                                                    (when carry-forward?
-                                                      (:winners-by-col state))
+                                                    (:winners-by-col state)
                                                     distal-sg
                                                     (:distal-bits distal-state)
                                                     (:distal-exc distal-state)
@@ -796,8 +794,7 @@
            b-cols :burst-cols
            stable-ac :stable-active-cells}
           (select-active-cells a-cols rel-cell-exc
-                               (when carry-forward? ;; keep winners stable
-                                 (:winners-by-col state))
+                               (:winners-by-col state) ;; keep winners stable
                                spec rng*)
           ;; learning cells are the winners in newly active columns
           learning (vals (apply dissoc wbc (:active-cols state)))

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -796,8 +796,13 @@
           (select-active-cells a-cols rel-cell-exc
                                (:winners-by-col state) ;; keep winners stable
                                spec rng*)
-          ;; learning cells are the winners in newly active columns
-          learning (vals (apply dissoc wbc (:active-cols state)))
+          ;; learning cells are the winning cells, but excluding any
+          ;; continuing winners when temporal pooling
+          old-winners (vals (:winners-by-col state))
+          new-winners (vals wbc)
+          learning (if newly-engaged? ;; always true at first level
+                     new-winners
+                     (remove (set old-winners) new-winners))
           ;; update continuing TP activation
           next-tp-exc (if higher-level?
                         (let [new-ac (set/difference ac (:active-cells state))]

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -799,11 +799,8 @@
                                (when carry-forward? ;; keep winners stable
                                  (:winners-by-col state))
                                spec rng*)
-          ;; learning cells are the new winners, excluding any continuing
-          old-winners (vals (:winners-by-col state))
-          new-winners (vals wbc)
-          learning (->> new-winners
-                        (remove (set old-winners)))
+          ;; learning cells are the winners in newly active columns
+          learning (vals (apply dissoc wbc (:active-cols state)))
           ;; update continuing TP activation
           next-tp-exc (if higher-level?
                         (let [new-ac (set/difference ac (:active-cells state))]

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -428,7 +428,7 @@
            best-ids ()
            best-exc 0.0
            good-ids () ;; over threshold
-           min-good-exc (double (* (inc threshold) 1000))]
+           second-exc (double threshold)]
       (if-let [id (first ids)]
         (let [exc (double (cell-exc id 0))
               equal-best? (== exc best-exc)
@@ -440,7 +440,11 @@
                        :else best-ids)
                  (if new-best? exc best-exc)
                  (if good? (conj good-ids id) good-ids)
-                 (if (and good? (< exc min-good-exc)) exc min-good-exc)))
+                 (if new-best?
+                   best-exc
+                   (if (< second-exc exc best-exc)
+                     exc
+                     second-exc))))
         ;; finished
         (let [winner (cond
                        (empty? best-ids)
@@ -455,12 +459,12 @@
                         ;; stimulus threshold not reached
                         (< best-exc threshold)
                         cell-ids
-                        ;; of cells over threshold, spread within dominance-margin
-                        (< (- best-exc min-good-exc) dominance-margin)
-                        good-ids
-                        ;; otherwise best cell(s) exceed others by dominance-margin
+                        ;; best cells exceed all others by dominance-margin
+                        (>= (- best-exc second-exc) dominance-margin)
+                        best-ids
+                        ;; otherwise, all cells over threshold become active
                         :else
-                        best-ids)]
+                        good-ids)]
           [winner actives])))))
 
 (defn select-active-cells

--- a/src/org/nfrac/comportex/columns.cljc
+++ b/src/org/nfrac/comportex/columns.cljc
@@ -71,14 +71,14 @@
 ;;; ## Overlaps
 
 (defn apply-overlap-boosting
-  "Given a map `exc` of the column overlap counts, filters it down
-  to those meeting parameter `ff-stimulus-threshold`, and
-  multiplies the excitation value by the column boosting factor."
+  "Given a map `exc` of the column overlap counts, multiplies the
+  excitation value by the corresponding column boosting factor."
   [exc boosts]
   (->> exc
-       (reduce-kv (fn [m [col _] x]
-                    (let [b (get boosts col)]
-                      (assoc! m col (* x b))))
+       (reduce-kv (fn [m id x]
+                    (let [[col _] id
+                          b (get boosts col)]
+                      (assoc! m id (* x b))))
                   (transient {}))
        (persistent!)))
 

--- a/src/org/nfrac/comportex/protocols.cljc
+++ b/src/org/nfrac/comportex/protocols.cljc
@@ -75,10 +75,11 @@
     "The set of active column ids.")
   (active-cells [this]
     "The set of active cell ids.")
-  (learnable-cells [this]
-    "The set of active, learnable cell ids. These are the winning
-    cells in each active column, and could be thought of as having
-    more prolonged activation than other active cells.")
+  (winner-cells [this]
+    "The set of winning cell ids, one in each active column. These are
+    _learning_ cells when they turn on, and _learnable_ cells when
+    they turn off. They could be thought of as having more prolonged
+    activation than other active cells.")
   (temporal-pooling-cells [this]
     "The collection of temporal pooling cells, i.e. those having some
     non-zero level of continuing temporal pooling excitation.")

--- a/test/org/nfrac/comportex/excitation_breakdowns_test.cljc
+++ b/test/org/nfrac/comportex/excitation_breakdowns_test.cljc
@@ -48,12 +48,12 @@
         htm (p/htm-step prev-htm (first continued))]
     (testing "Cell excitation breakdowns"
       (let [lyr (get-in htm [:regions :rgn-0 :layer-3])
-            lc (p/learnable-cells lyr)
+            wc (p/winner-cells lyr)
             bd (core/cell-excitation-breakdowns htm prev-htm :rgn-0 :layer-3
-                                                (conj lc [0 0]))]
-        (is (every? (comp pos? :total) (map bd lc))
+                                                (conj wc [0 0]))]
+        (is (every? (comp pos? :total) (map bd wc))
             "All total excitation in range.")
-        (is (every? (comp pos? first vals :proximal-unstable) (map bd lc))
+        (is (every? (comp pos? first vals :proximal-unstable) (map bd wc))
             "Some proximal excitation on each active column")
         (is (every? (comp zero? :temporal-pooling) (vals bd))
             "Zero TP excitation in first layer.")


### PR DESCRIPTION
This rewrite comes from taking seriously the need for sequence learning at higher levels. At higher levels we have temporal slowness: cells stay active for longer, i.e. several time steps. If there is a uniform cortical algorithm then we need the usual sequence learning to work under temporal slowness. I think that means discrete transitions.
    
I define a threshold fraction of stable inputs to a layer for it to be _engaged_. Only when a layer is newly engaged does it replace its active columns based on the stable input. At other times, these active columns and cells continue to stay active. The exception is any columns which have a definite (high) match to input bits, and the relative influence of these over continuing columns is controlled by a parameter (`temporal-pooling-max-exc`).
    
Active columns learn on proximal dendrites as long as the layer is _engaged_, meaning it has continuing stable input.
    
For learning on distal dendrites, define:
* _learning_ cells - the new winning cells, excluding any continuing.
* _learnable_ cells - the previous winning cells, excluding any continuing.

And each time step, the learning cells can grow synapses to the learnable cells. This applies in all layers, not just higher temporal pooling layers. Notably it has a big effect on gradual continuous sequence learning, such as with the coordinate encoder. That will probably cause problems because there might not be enough coincidences of some cells starting while others are stopping. Maybe the learnable cells should remain learnable for a few time steps.

I'm not sure the old way was much better because it would end up with a lot of cells connecting to the other ones representing the same coordinate, which is not useful sequence information.

Obviously, this is all experimental. I haven't really experimented with it to see how the temporal pooling properties hold up. But what we had didn't work anyway, so might as well replace it.

