### PR TITLE
Seq replay mechanism and options

### DIFF
--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -930,7 +930,9 @@
                                           (:depth spec))
           ;; union temporal pooling: accrete more columns as pooling continues
           activation-level (let [base-level (:activation-level spec)
-                                 prev-level (/ (count (:active-cols state))
+                                 prev-ncols (->> (keys (:temporal-pooling-exc state))
+                                                 (map first) (distinct) (count))
+                                 prev-level (/ prev-ncols
                                                (p/size-of this))]
                              (if (or newly-engaged? (not engaged?))
                                base-level

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -935,7 +935,7 @@
                              (if (or newly-engaged? (not engaged?))
                                base-level
                                (min (:activation-level-max spec)
-                                    (+ prev-level (* 0.5 base-level)))))
+                                    (+ prev-level base-level))))
           a-cols (select-active-columns (best-by-column abs-cell-exc)
                                         topology activation-level
                                         inh-radius spec)


### PR DESCRIPTION
The main part of this is making apical predictions dependent on corresponding lateral predictions, which may or may not be the final solution but certainly makes more sense than the current approach.

I added an option for temporal pooling to continue even in the face of bursting, in which case presumably it would be reset manually.

TP levels are set proportionally to the initial total excitation. May become irrelevant if we switch to Yuwei/Scott's idea of persistent synapses instead of persistent cells.

~~Also added an option for immediate learning of novel sequences, which comes at a cost of reusing cells from other contexts. Very experimental (even more than everything else).~~