### PR TITLE
Decomplect layer-activate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Change Log
+
+## [Unreleased]
+### Changed
+- Winner cells are not selected in layer-activate phase, only later in
+  the layer-learn phase.
+- LayerActiveState no longer has keys :distal-learning, :proximal-learning, etc.
+- LayerOfCells now has key :learn-state which is a LayerLearnState record.
+- Abandoned the bias against cells with existing inactive segments.
+- :matching-[ff-]seg-paths now holds [seg-path exc] tuples instead of just seg-path.
+- Removed :well-matching-seg-paths and :well-matching-ff-seg-paths.
+
+### Added
+- LayerActiveState gains a key :col-active-cells, a map keyed by col id.
+
+### Fixed
+- Segments with connected synapses below :new-synapse-count but above
+  :stimulus-threshold were not automatically chosen, instead falling
+  through to partial matches (including disconnected synapses).
+- The wrong segment index was chosen for a partial match when some
+  cells had no segments. (cell-segs was filtered)
+
+## [0.0.12] - 2015-12-01
+- Before this I didn't keep a change log.
+
+[Unreleased]: https://github.com/nupic-community/comportex/compare/v0.0.12...HEAD
+[0.0.12]: https://github.com/nupic-community/comportex/compare/v0.0.10...v0.0.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 - Abandoned the bias against cells with existing inactive segments.
 - :matching-[ff-]seg-paths now holds [seg-path exc] tuples instead of just seg-path.
 - Removed :well-matching-seg-paths and :well-matching-ff-seg-paths.
+- In LayerDistalState renamed :on-bits to :active-bits
+  and :on-lc-bits to :learnable-bits
 
 ### Added
 - LayerActiveState gains a key :col-active-cells, a map keyed by col id.

--- a/project.clj
+++ b/project.clj
@@ -1,14 +1,14 @@
-(defproject org.nfrac/comportex "0.0.12-SNAPSHOT"
+(defproject org.nfrac/comportex "0.0.13-SNAPSHOT"
   :description "Functionally composable cortex, an implementation of Hierarchical Temporal Memory"
   :url "http://github.com/nupic-community/comportex/"
   :license {:name "GNU Affero General Public Licence"
             :url "http://www.gnu.org/licenses/agpl-3.0.en.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [org.clojure/core.async "0.1.346.0-17112a-alpha"]
-                 [org.clojure/data.int-map "0.1.0"]
-                 [org.clojure/test.check "0.8.2"]
-                 [clj-http "1.1.1"]
-                 [cljs-http "0.1.30"]]
+  :dependencies [[org.clojure/clojure "1.8.0-RC2"]
+                 [org.clojure/core.async "0.2.374"]
+                 [org.clojure/data.int-map "0.2.1"]
+                 [org.clojure/test.check "0.9.0"]
+                 [clj-http "2.0.0"]
+                 [cljs-http "0.1.38"]]
 
   :jvm-opts ^:replace ["-server" "-Xmx2500m"]
 
@@ -16,7 +16,7 @@
                         :compiler {:output-to "target/testable.js"
                                    :optimizations :advanced}}]}
 
-  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.7.107"]
+  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.7.189"]
                                   [criterium "0.4.3"]]
                    :plugins [[lein-cljsbuild "1.1.0"]
                              [com.cemerick/clojurescript.test "0.3.3"]

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -940,18 +940,14 @@
 
 (defn compute-active-state
   [state ff-bits stable-ff-bits proximal-sg distal-state apical-state
-   boosts topology inh-radius spec engaged?]
+   boosts topology inh-radius spec]
   (let [;; proximal excitation as number of active synapses, keyed by [col 0 seg-idx]
         col-seg-overlaps (p/excitations proximal-sg ff-bits
                                         (:stimulus-threshold (:proximal spec)))
         ;; these both keyed by [col 0]
         [raw-col-exc ff-seg-paths]
         (best-segment-excitations-and-paths col-seg-overlaps)
-        col-exc (cond-> raw-col-exc
-                  (not engaged?)
-                  (select-keys (keys ff-seg-paths))
-                  true
-                  (columns/apply-overlap-boosting boosts))
+        col-exc (columns/apply-overlap-boosting raw-col-exc boosts)
         tp-exc (:temporal-pooling-exc state)
         ;; ignore apical excitation unless there is matching distal.
         ;; unlike other segments, allow apical excitation to add to distal
@@ -1028,8 +1024,7 @@
         (compute-active-state (assoc state :temporal-pooling-exc tp-exc)
                               ff-bits stable-ff-bits proximal-sg distal-state
                               apical-state boosts topology inh-radius
-                              (assoc spec :activation-level activation-level)
-                              engaged?)
+                              (assoc spec :activation-level activation-level))
         ;; update continuing TP activation
         ac (:active-cells next-state)
         next-tp-exc (if higher-level?

--- a/src/org/nfrac/comportex/core.cljc
+++ b/src/org/nfrac/comportex/core.cljc
@@ -685,8 +685,8 @@
         ff-bits (:in-ff-bits state)
         ff-s-bits (:in-stable-ff-bits state)
         ff-b-bits (set/difference ff-bits ff-s-bits)
-        distal-bits (:on-bits distal-state)
-        apical-bits (:on-bits apical-state)
+        distal-bits (:active-bits distal-state)
+        apical-bits (:active-bits apical-state)
         is-input-layer? (= lyr-id (first (layers rgn)))
         ff-bits-srcs (if is-input-layer?
                        (into {}

--- a/src/org/nfrac/comportex/core.cljc
+++ b/src/org/nfrac/comportex/core.cljc
@@ -719,7 +719,7 @@
           (map (fn [cell-id]
                  (let [[col ci] cell-id
                        ;; breakdown of proximal excitation by source
-                       ff-seg-path (get (:matching-ff-seg-paths state) [col 0])
+                       [ff-seg-path _] (get (:matching-ff-seg-paths state) [col 0])
                        ff-conn-sources (when ff-seg-path
                                          (p/sources-connected-to psg ff-seg-path))
                        active-ff-b (->> (filter ff-b-bits ff-conn-sources)
@@ -729,7 +729,7 @@
                        ff-b-by-src (frequencies (map ff-bits-srcs active-ff-b))
                        ff-s-by-src (frequencies (map ff-bits-srcs active-ff-s))
                        ;; breakdown of distal excitation by source
-                       d-seg-path (get (:matching-seg-paths distal-state) cell-id)
+                       [d-seg-path _] (get (:matching-seg-paths distal-state) cell-id)
                        d-conn-sources (when d-seg-path
                                         (p/sources-connected-to dsg d-seg-path))
                        active-d (->> (filter distal-bits d-conn-sources)
@@ -737,7 +737,7 @@
                        d-by-src (->> (frequencies (map distal-bits-srcs active-d))
                                      (util/remap #(* % distal-weight)))
                        ;; same for apical
-                       a-seg-path (get (:matching-seg-paths apical-state) cell-id)
+                       [a-seg-path _] (get (:matching-seg-paths apical-state) cell-id)
                        a-conn-sources (when a-seg-path
                                         (p/sources-connected-to asg a-seg-path))
                        active-a (->> (filter apical-bits a-conn-sources)

--- a/src/org/nfrac/comportex/repl.cljc
+++ b/src/org/nfrac/comportex/repl.cljc
@@ -36,9 +36,10 @@
                       [:col-overlaps :matching-ff-seg-paths
                        :in-ff-bits :in-stable-ff-bits
                        :out-ff-bits :out-stable-ff-bits
-                       :active-cells]
+                       :active-cells :col-overlaps
+                       :temporal-pooling-exc]
                       LayerDistalState
-                      [:on-bits :on-lc-bits :cell-exc :pred-cells
+                      [:active-bits :learnable-bits :cell-exc :pred-cells
                        :matching-seg-paths]})
 
 (defrecord TruncateOnPrint [v])


### PR DESCRIPTION
Separated cell activation from winner cell selection. And cell activation from temporal pooling logic.

A new (obvious?) axiom for the design: selecting winner cells should
happen in the learn phase.

Think of the learn phase as on a slower time scale than the activate
phase; only in the latter phase do sub-connected (weakly-connected?)
synapses have any effect.

Now the selection of winner cells and segments is centralised into one
place.

Pulled out the learning-related state into a new :learn-state record.

Started a CHANGELOG.md