### PR TITLE
apical-bias-frac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 
 ### Added
 - LayerActiveState gains a key :col-active-cells, a map keyed by col id.
+- Spec parameter :apical-bias-frac
 
 ### Fixed
 - Segments with connected synapses below :new-synapse-count but above


### PR DESCRIPTION
On the principle that cell-representations of the same input in similar pooled-feedback contexts should overlap, even if their immediate lateral context is different.

Uses apical excitation to influence winner cell selection with some probability.
