### PR TITLE
Temporal Pooling using synapses not cells

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 # Change Log
 
 ## [Unreleased]
+### Changed
+- No more temporal pooling excitation. Instead, synapses from predicted
+  cells excite their target cells over multiple time steps.
+- No more union pooling; activation level is constant.
+- First level layers are not treated any differently from higher layers.
+  - Proximal synapses grow to any active synapses, not just stable ones.
+  - Winner cells remain the same in continuing active columns unless reset;
+    we may rely on an external timing signal to distinguish repeats.
+  - Learn on winner cells only when they become active (even at first level).
+    But might revisit this to learn auto-associatively for pattern completion.
+
+### Added
+- Spec parameter :stable-activation-steps
+- State key :stable-cells-buffer
+
+### Removed
+- Spec parameters :temporal-pooling-max-exc, -fall, -amp
+- Spec parameters :activation-level-max, :stable-inbit-frac-threshold
+- State keys :engaged?, :newly-engaged?
+- temporal-pooling-cells protocol function.
 
 ## [0.0.13] - 2016-01-12
 ### Changed

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -1046,10 +1046,11 @@
   (layer-depolarise
     [this distal-ff-bits apical-fb-bits apical-fb-wc-bits]
     (let [depth (:depth spec)
+          ac (:active-cells state)
           widths (distal-sources-widths spec)
           distal-bits (util/align-indices widths
                                           [(if (:lateral-synapses? spec)
-                                             (:out-ff-bits state)
+                                             (cells->bits depth ac)
                                              [])
                                            distal-ff-bits])
           wc (vals (:col-winners learn-state))

--- a/src/org/nfrac/comportex/cells.cljc
+++ b/src/org/nfrac/comportex/cells.cljc
@@ -198,6 +198,7 @@
               :perm-connected 0.20
               :perm-init 0.25
               :learn? true
+              :grow? false
               }
    :distal (assoc dendrite-parameter-defaults
                   :learn? true)
@@ -840,7 +841,8 @@
         prox-learning (learning-updates ids
                                         matching-segs
                                         sg
-                                        (:in-ff-bits state)
+                                        (when (:grow? pspec)
+                                          (:in-ff-bits state))
                                         rng* pspec)
         psg (cond-> sg
               (seq prox-learning)

--- a/src/org/nfrac/comportex/core.cljc
+++ b/src/org/nfrac/comportex/core.cljc
@@ -665,7 +665,6 @@
   * :proximal-stable - a map keyed by source region/sense id.
   * :distal - a map keyed by source region/sense id.
   * :boost - number.
-  * :temporal-pooling - number.
   "
   [htm prior-htm rgn-id lyr-id cell-ids]
   (let [rgn (get-in htm [:regions rgn-id])
@@ -676,7 +675,6 @@
         d-stim-thresh (:stimulus-threshold (:distal spec))
         a-stim-thresh (:stimulus-threshold (:apical spec))
         distal-weight (:distal-vs-proximal-weight spec)
-        tp-fall (:temporal-pooling-fall spec)
         state (:state lyr)
         prior-state (:state prior-lyr)
         distal-state (:distal-state prior-lyr)
@@ -713,8 +711,7 @@
         dsg (:distal-sg prior-lyr)
         asg (:apical-sg prior-lyr)
         ;; internal sources
-        boosts (:boosts prior-lyr)
-        p-tp-exc (:temporal-pooling-exc prior-state)]
+        boosts (:boosts prior-lyr)]
     (into {}
           (map (fn [cell-id]
                  (let [[col ci] cell-id
@@ -752,17 +749,12 @@
                        ;; effect of boosting
                        overlap (+ b-overlap s-overlap)
                        boost-amt (* overlap (- (get boosts col) 1.0))
-                       ;; temporal pooling excitation (see cells/decay-tp)
-                       prior-tp (max 0 (- (get p-tp-exc cell-id 0.0)
-                                          tp-fall
-                                          b-overlap))
                        ;; total excitation
-                       total (+ b-overlap s-overlap boost-amt prior-tp d-a-exc)]
+                       total (+ b-overlap s-overlap boost-amt d-a-exc)]
                    [cell-id {:total total
                              :proximal-unstable ff-b-by-src
                              :proximal-stable ff-s-by-src
                              :boost boost-amt
-                             :temporal-pooling prior-tp
                              :distal (merge d-by-src a-by-src)}])))
           cell-ids)))
 

--- a/src/org/nfrac/comportex/demos/second_level_motor.cljc
+++ b/src/org/nfrac/comportex/demos/second_level_motor.cljc
@@ -40,13 +40,16 @@ the three little pigs.
               :perm-dec 0.01}
    :lateral-synapses? true
    :distal-vs-proximal-weight 0.0
-   :use-feedback? false
+   :use-feedback? true
+   :apical {:learn? true}
    })
 
 (def higher-level-spec
   (util/deep-merge
    spec
    {:column-dimensions [800]
+    :stable-inbit-frac-threshold 0.5
+    :ff-init-frac 0.05
     :proximal {:max-segments 5
                :new-synapse-count 12
                :learn-threshold 6}}))
@@ -141,15 +144,13 @@ the three little pigs.
           end-of-passage? (= i (dec (count sentences)))
           r0-lyr (get-in htm-a [:regions :rgn-0 :layer-3])
           r1-lyr (get-in htm-a [:regions :rgn-1 :layer-3])
-          r0-burst-frac (/ (* (p/layer-depth r0-lyr) ;; number of cells
-                              (count (p/bursting-columns r0-lyr)))
-                           (max 1 (count (p/active-cells r0-lyr))))
+          r1-engaged? (:engaged? (:state r1-lyr))
           word-burst? (cond-> (:word-bursting? (:action inval))
                         ;; ignore burst on first letter of word
-                        (pos? k) (or (>= r0-burst-frac 0.50)))
+                        (pos? k) (or (not r1-engaged?)))
           sent-burst? (cond-> (:sentence-bursting? (:action inval))
                         ;; ignore burst on first letter of word
-                        (pos? k) (or (>= r0-burst-frac 0.50)))
+                        (pos? k) (or (not r1-engaged?)))
           action* (cond
                     ;; not yet at end of word
                     (not end-of-word?)
@@ -159,12 +160,14 @@ the three little pigs.
 
                     ;; word not yet learned, repeat word
                     word-burst?
-                    {:word-bursting? false}
+                    {:next-letter-saccade -1
+                     :word-bursting? false}
 
                     ;; go to next word (not yet at end of sentence)
                     ;; same letter-motor signal as when repeating a word
                     (not end-of-sentence?)
                     {:next-word-saccade 1
+                     :next-letter-saccade -1
                      :word-bursting? false}
 
                     ;; end of sentence.
@@ -172,6 +175,7 @@ the three little pigs.
                     ;; sentence not yet learned, repeat sentence
                     sent-burst?
                     {:next-word-saccade -1
+                     :next-letter-saccade -1
                      :word-bursting? false
                      :sentence-bursting? false}
 
@@ -179,19 +183,20 @@ the three little pigs.
                     (not end-of-passage?)
                     {:next-sentence-saccade 1
                      :next-word-saccade 1
+                     :next-letter-saccade -1
                      :word-bursting? false
                      :sentence-bursting? false}
 
                     ;; reached end of passage
                     :else
                     {:next-word-saccade -1
+                     :next-letter-saccade -1
                      :word-bursting? false
                      :sentence-bursting? false}
                     )
           ;; next-letter-saccade represents starting a word (-1) or continuing (1)
           ;; that is all that rgn-0 knows.
-          action (merge {:next-letter-saccade -1
-                         :next-word-saccade 0
+          action (merge {:next-word-saccade 0
                          :next-sentence-saccade 0
                          :word-bursting? word-burst?
                          :sentence-bursting? sent-burst?}
@@ -207,9 +212,14 @@ the three little pigs.
         (p/htm-sense inval-with-action :motor)
         true
         (p/htm-depolarise)
-        ;; reset first region's sequence when going on to new word
-        (and end-of-word? (not word-burst?))
+        ;; break sequence when repeating word (but keep tp synapses)
+        end-of-word?
         (update-in [:regions :rgn-0] p/break :tm)
+        ;; reset context when going on to new word
+        (and end-of-word? (not word-burst?))
+        (update-in [:regions :rgn-0] p/break :syns)
+        (and end-of-word? (not word-burst?))
+        (update-in [:regions :rgn-1] p/break :winners)
         ))))
 
 (comment

--- a/src/org/nfrac/comportex/demos/second_level_motor.cljc
+++ b/src/org/nfrac/comportex/demos/second_level_motor.cljc
@@ -144,13 +144,14 @@ the three little pigs.
           end-of-passage? (= i (dec (count sentences)))
           r0-lyr (get-in htm-a [:regions :rgn-0 :layer-3])
           r1-lyr (get-in htm-a [:regions :rgn-1 :layer-3])
-          r1-engaged? (:engaged? (:state r1-lyr))
+          r0-stability (/ (count (:out-stable-ff-bits (:state r0-lyr)))
+                          (count (:out-ff-bits (:state r0-lyr))))
           word-burst? (cond-> (:word-bursting? (:action inval))
                         ;; ignore burst on first letter of word
-                        (pos? k) (or (not r1-engaged?)))
+                        (pos? k) (or (< r0-stability 0.5)))
           sent-burst? (cond-> (:sentence-bursting? (:action inval))
                         ;; ignore burst on first letter of word
-                        (pos? k) (or (not r1-engaged?)))
+                        (pos? k) (or (< r0-stability 0.5)))
           action* (cond
                     ;; not yet at end of word
                     (not end-of-word?)

--- a/src/org/nfrac/comportex/protocols.cljc
+++ b/src/org/nfrac/comportex/protocols.cljc
@@ -83,9 +83,6 @@
     "The set of winning cell ids, one in each active column. These are
     only _learning_ cells when they turn on, but are always
     _learnable_.")
-  (temporal-pooling-cells [this]
-    "The collection of temporal pooling cells, i.e. those having some
-    non-zero level of continuing temporal pooling excitation.")
   (predictive-cells [this]
     "The set of predictive cell ids derived from the current active
     cells. If the depolarise phase has not been applied yet, returns
@@ -150,11 +147,16 @@
   (break [this mode]
     "Returns this model (or model component) without its current
     sequence state, forcing the following input to be treated as a new
-    sequence. If mode is :tm, cancels any distal predictions and
-    prevents learning lateral/distal connections. If mode is :fb,
-    cancels any feedback predictions and prevents learning connections
-    on apical dendrites. If mode is :tp, cancels any temporal pooling
-    potential."))
+    sequence. `mode` can be
+
+    * :tm, cancels any distal predictions and prevents learning
+      lateral/distal connections.
+    * :fb, cancels any feedback predictions and prevents learning
+      connections on apical dendrites.
+    * :syns, cancels any continuing stable synapses used for temporal
+      pooling in any higher layers (not `this` layer).
+    * :winners, allows new winner cells to be chosen in continuing
+      columns."))
 
 (defprotocol PTemporal
   (timestep [this]))


### PR DESCRIPTION
Based on the idea from Numenta of minibursts from predicted cells causing extended depolarisation via metabotropic receptors.

- No more temporal pooling excitation. Instead, synapses from predicted
  cells excite their target cells over multiple time steps.
- No more union pooling; activation level is constant.
- First level layers run exactly the same algorithm as higher layers:
  - Proximal synapses grow to any active synapses, not just stable ones.
  - Winner cells remain the same in continuing active columns unless reset;
    we may rely on an external timing signal to distinguish repeats.
  - Learn on winner cells only when they become active (even at first level).
    But might revisit this to learn auto-associatively for pattern completion.

Testing informally on the second-level-motor demo gives plausible results. The activated higher layer columns include some of those from previous predicted states. Obviously needs a lot more testing and development.
